### PR TITLE
feat: Implement swipe for track changes and reduce lyrics text size

### DIFF
--- a/app/src/main/java/org/akanework/gramophone/ui/components/NewLyricsView.kt
+++ b/app/src/main/java/org/akanework/gramophone/ui/components/NewLyricsView.kt
@@ -56,10 +56,12 @@ class NewLyricsView(context: Context, attrs: AttributeSet?) : View(context, attr
     private val prefs = PreferenceManager.getDefaultSharedPreferences(context)
     private lateinit var typeface: Typeface
     private val grdWidth = context.resources.getDimension(R.dimen.lyric_gradient_size)
-    private val defaultTextSize = context.resources.getDimension(R.dimen.lyric_text_size)
-    private val translationTextSize = context.resources.getDimension(R.dimen.lyric_tl_text_size)
+    // Original values: R.dimen.lyric_text_size, R.dimen.lyric_tl_text_size, R.dimen.lyric_tl_bg_text_size
+    // Consider making these configurable in preferences or dimens.xml if further changes are needed.
+    private val defaultTextSize = context.resources.getDimension(R.dimen.lyric_text_size) - 2f.dpToPx(context) // Reduced by 2sp
+    private val translationTextSize = context.resources.getDimension(R.dimen.lyric_tl_text_size) - 2f.dpToPx(context) // Reduced by 2sp
     private val translationBackgroundTextSize =
-        context.resources.getDimension(R.dimen.lyric_tl_bg_text_size)
+        context.resources.getDimension(R.dimen.lyric_tl_bg_text_size) - 2f.dpToPx(context) // Reduced by 2sp
     private val globalPaddingTop = context.resources.getDimensionPixelSize(R.dimen.lyric_top_padding)
     private val globalPaddingBottom =
         context.resources.getDimensionPixelSize(R.dimen.lyric_bottom_padding)
@@ -884,7 +886,23 @@ class NewLyricsView(context: Context, attrs: AttributeSet?) : View(context, attr
         velocityX: Float,
         velocityY: Float
     ): Boolean {
-        return false // handled by parent
+        if (e1 == null) return false // Should not happen with a valid fling
+        val diffX = e2.x - e1.x
+        val diffY = e2.y - e1.y
+        if (Math.abs(diffX) > Math.abs(diffY)) {
+            if (Math.abs(diffX) > 100 && Math.abs(velocityX) > 100) {
+                if (diffX > 0) {
+                    // Right swipe
+                    (context as? MainActivity)?.getPlayer()?.seekToPrevious()
+                } else {
+                    // Left swipe
+                    (context as? MainActivity)?.getPlayer()?.seekToNext()
+                }
+                return true
+            }
+        }
+        // If not a horizontal fling, let parent NestedScrollView handle vertical scroll
+        return super.onFling(e1, e2, velocityX, velocityY)
     }
 
     data class SbItem(

--- a/app/src/main/java/org/akanework/gramophone/ui/components/PlayerBottomSheet.kt
+++ b/app/src/main/java/org/akanework/gramophone/ui/components/PlayerBottomSheet.kt
@@ -22,6 +22,8 @@ import android.os.Handler
 import android.os.Looper
 import android.util.AttributeSet
 import android.util.Log
+import android.view.GestureDetector
+import android.view.MotionEvent
 import android.view.View
 import android.view.WindowInsets
 import android.widget.FrameLayout
@@ -92,6 +94,7 @@ class PlayerBottomSheet private constructor(
     private val lifecycleOwner: LifecycleOwner
         get() = activity
     private val handler = Handler(Looper.getMainLooper())
+    private val gestureDetector: GestureDetector
     private val instance: MediaController?
         get() = activity.getPlayer()
     private var lastActuallyVisible: Boolean? = null
@@ -140,6 +143,35 @@ class PlayerBottomSheet private constructor(
             ViewCompat.performHapticFeedback(it, HapticFeedbackConstantsCompat.CONTEXT_CLICK)
             instance?.seekToNext()
         }
+
+        gestureDetector = GestureDetector(context, object : GestureDetector.SimpleOnGestureListener() {
+            override fun onFling(
+                e1: MotionEvent?,
+                e2: MotionEvent,
+                velocityX: Float,
+                velocityY: Float
+            ): Boolean {
+                if (standardBottomSheetBehavior?.state == BottomSheetBehavior.STATE_HIDDEN || standardBottomSheetBehavior?.state == BottomSheetBehavior.STATE_DRAGGING) {
+                    return false
+                }
+
+                val diffX = e2.x - (e1?.x ?: 0f)
+                val diffY = e2.y - (e1?.y ?: 0f)
+                if (Math.abs(diffX) > Math.abs(diffY)) {
+                    if (Math.abs(diffX) > 100 && Math.abs(velocityX) > 100) {
+                        if (diffX > 0) {
+                            // Right swipe
+                            instance?.seekToPrevious()
+                        } else {
+                            // Left swipe
+                            instance?.seekToNext()
+                        }
+                        return true
+                    }
+                }
+                return false
+            }
+        })
 
         activity.controllerViewModel.addControllerCallback(activity.lifecycle) { _, _ ->
             instance?.addListener(this@PlayerBottomSheet)
@@ -419,4 +451,15 @@ class PlayerBottomSheet private constructor(
         fullPlayer.onStop()
     }
 
+    override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {
+        if (ev != null) {
+            return gestureDetector.onTouchEvent(ev) || super.onInterceptTouchEvent(ev)
+        }
+        return super.onInterceptTouchEvent(ev)
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        return gestureDetector.onTouchEvent(event) || super.onTouchEvent(event)
+    }
 }


### PR DESCRIPTION
Implemented swipe gestures for track changes in:
- PlayerBottomSheet (mini-player and full player)
- NewLyricsView (lyrics screen)

Reduced the text size for lyrics in NewLyricsView for a slightly smaller appearance.

## Summary by Sourcery

Add horizontal swipe gestures for track navigation in PlayerBottomSheet and NewLyricsView, and decrease lyrics font sizes in NewLyricsView.

New Features:
- Add horizontal swipe gestures to PlayerBottomSheet for previous/next track navigation
- Add horizontal swipe gestures to NewLyricsView for previous/next track navigation

Enhancements:
- Reduce lyrics text sizes by 2sp in NewLyricsView for a more compact display